### PR TITLE
Promotion code, SMARTPAY_CHECKOUT_URL, bugfix

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 
 Style/StringLiterals:
   Enabled: true

--- a/lib/smartpay.rb
+++ b/lib/smartpay.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require 'json'
+require "json"
 
 require_relative "smartpay/version"
-require_relative 'smartpay/configuration'
-require_relative 'smartpay/client'
-require_relative 'smartpay/api'
-require_relative 'smartpay/errors/invalid_request_payload_error'
-require_relative 'smartpay/requests/checkout_session'
-require_relative 'smartpay/responses/checkout_session'
+require_relative "smartpay/configuration"
+require_relative "smartpay/client"
+require_relative "smartpay/api"
+require_relative "smartpay/errors/invalid_request_payload_error"
+require_relative "smartpay/requests/checkout_session"
+require_relative "smartpay/responses/checkout_session"
 
 module Smartpay
   class << self

--- a/lib/smartpay/api.rb
+++ b/lib/smartpay/api.rb
@@ -5,7 +5,7 @@ module Smartpay
     class << self
       def create_checkout_session(payload)
         Responses::CheckoutSession.new(
-          Client.post('/checkout-sessions', Requests::CheckoutSession.new(payload).as_hash)
+          Client.post("/checkout-sessions", Requests::CheckoutSession.new(payload).as_hash)
         )
       end
     end

--- a/lib/smartpay/client.rb
+++ b/lib/smartpay/client.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
-require 'rest-client'
+require "rest-client"
 
 module Smartpay
   class Client
     class << self
       def post(path, payload = {})
         request_payload = default_payload.merge(payload)
-        response = RestClient::Request.execute(method: :post, url: api_url(path), headers: headers, timeout: timeout, payload: request_payload.to_json)
+        response = RestClient::Request.execute(method: :post, url: api_url(path), headers: headers, timeout: timeout,
+                                               payload: request_payload.to_json)
         JSON.parse(response.body, symbolize_names: true)
       end
 

--- a/lib/smartpay/configuration.rb
+++ b/lib/smartpay/configuration.rb
@@ -6,17 +6,21 @@ module Smartpay
     attr_writer :post_timeout, :api_url, :checkout_url
 
     DEFAULT_TIMEOUT_SETTING = 30
-    DEFAULT_API_URL = 'https://api.smartpay.co/v1'
-    DEFAULT_CHECKOUT_URL = 'https://checkout.smartpay.co'
+    DEFAULT_API_URL = "https://api.smartpay.co/v1"
+    DEFAULT_CHECKOUT_URL = "https://checkout.smartpay.co"
 
     def initialize
       @post_timeout = DEFAULT_TIMEOUT_SETTING
       @api_url = if in_development_mode?
-                   ENV['SMARTPAY_API_PREFIX'].downcase || DEFAULT_API_URL
+                   ENV["SMARTPAY_API_PREFIX"].downcase || DEFAULT_API_URL
                  else
                    DEFAULT_API_URL
                  end
-      @checkout_url = DEFAULT_CHECKOUT_URL
+      @checkout_url = if in_development_mode? && ENV["SMARTPAY_CHECKOUT_URL"].is_a?(String)
+                        ENV["SMARTPAY_CHECKOUT_URL"].downcase || DEFAULT_CHECKOUT_URL
+                      else
+                        DEFAULT_CHECKOUT_URL
+                      end
     end
 
     def post_timeout
@@ -25,7 +29,7 @@ module Smartpay
 
     def api_url
       if in_development_mode?
-        @api_url || ENV['SMARTPAY_API_PREFIX'].downcase || DEFAULT_API_URL
+        @api_url || ENV["SMARTPAY_API_PREFIX"].downcase || DEFAULT_API_URL
       else
         @api_url || DEFAULT_API_URL
       end
@@ -38,9 +42,7 @@ module Smartpay
     private
 
     def in_development_mode?
-      if ENV['SMARTPAY_API_PREFIX'].is_a?(String)
-        ENV['SMARTPAY_API_PREFIX'].downcase.include?('api.smartpay')
-      end
+      ENV["SMARTPAY_API_PREFIX"].downcase.include?("api.smartpay") if ENV["SMARTPAY_API_PREFIX"].is_a?(String)
     end
   end
 end

--- a/lib/smartpay/requests/checkout_session.rb
+++ b/lib/smartpay/requests/checkout_session.rb
@@ -29,6 +29,10 @@ module Smartpay
       def normalize_payload
         currency = get_currency
         total_amount = get_total_amount
+        metadata = payload.dig(:metadata) || {}
+        promotion_code = payload.dig(:promotionCode)
+        
+        metadata[:__promotion_code__] = promotion_code if promotion_code
 
         {
           customerInfo: normalize_customer_info(payload.dig(:customerInfo) || payload.dig(:customer) || {}),
@@ -44,7 +48,7 @@ module Smartpay
             metadata: payload.dig(:orderMetadata)
           }),
           reference: payload.dig(:reference),
-          metadata: payload.dig(:metadata),
+          metadata: metadata,
           successUrl: payload.dig(:successURL),
           cancelUrl: payload.dig(:cancelURL),
           test: payload.dig(:test) || false

--- a/lib/smartpay/responses/checkout_session.rb
+++ b/lib/smartpay/responses/checkout_session.rb
@@ -9,8 +9,13 @@ module Smartpay
         @response = response
       end
 
-      def redirect_url
-        URI.escape("#{checkout_url}/login?session-id=#{response[:id]}&public-key=#{public_key}")
+      def redirect_url(options = {})
+        url = "#{checkout_url}/login"
+        promotion_code = options[:promotion_code] || response[:metadata][:__promotion_code__] || nil
+        qs = "session-id=#{URI.encode_www_form_component(response[:id])}&public-key=#{URI.encode_www_form_component(public_key)}"
+        qs = "#{qs}&promotion-code=#{URI.encode_www_form_component(promotion_code)}" if promotion_code
+        
+        "#{url}?#{qs}"
       end
 
       def as_hash

--- a/spec/fixtures/checkout_session_promotion.json
+++ b/spec/fixtures/checkout_session_promotion.json
@@ -1,0 +1,68 @@
+{
+  "id": "checkout_test_oTQpCvZzZ52UvKbrN5i4B8",
+  "object": "checkoutSession",
+  "cancelUrl": "https://docs.smartpay.co/example-pages/checkout-canceled",
+  "createdAt": 1633950354307,
+  "customerInfo": {
+    "emailAddress": "rejected@smartpay.co"
+  },
+  "metadata": {
+    "__promotion_code__": "ZOO"
+  },
+  "order": {
+    "id": "order_test_VUjhenWnjSmCSTPTuMMe9Z",
+    "object": "order",
+    "amount": 250,
+    "createdAt": 1633950354307,
+    "currency": "JPY",
+    "lineItems": [
+      {
+        "id": "li_test_PSY6hFtrd2U6x0zlOdJwMP",
+        "object": "lineItem",
+        "metadata": {},
+        "price": {
+          "id": "price_test_NVjsGSr4ANR7kRUtB75jni",
+          "object": "price",
+          "active": true,
+          "amount": 250,
+          "createdAt": 1633950354307,
+          "currency": "JPY",
+          "metadata": {},
+          "product": {
+            "id": "product_test_MbgXUIiqRbQcyEZQe35NRg",
+            "object": "product",
+            "active": true,
+            "categories": [],
+            "createdAt": 1633950354307,
+            "images": [],
+            "metadata": {},
+            "name": "レブロン 18 LOW",
+            "test": true,
+            "updatedAt": 1633950354307
+          },
+          "test": true,
+          "updatedAt": 1633950354307
+        },
+        "quantity": 1,
+        "test": true,
+        "updatedAt": 1633950354307
+      }
+    ],
+    "metadata": {},
+    "shippingInfo": {
+      "address": {
+        "line1": "line1",
+        "locality": "locality",
+        "postalCode": "123",
+        "country": "JP"
+      }
+    },
+    "status": "requires_authorization",
+    "test": true,
+    "updatedAt": 1633950354307
+  },
+  "successUrl": "https://docs.smartpay.co/example-pages/checkout-successful",
+  "reference": "order_ref_1234567",
+  "test": true,
+  "updatedAt": 1633950354307
+}

--- a/spec/smartpay/requests/checkout_session_spec.rb
+++ b/spec/smartpay/requests/checkout_session_spec.rb
@@ -54,7 +54,8 @@ RSpec.describe Smartpay::Requests::CheckoutSession do
           line1: "line1",
           locality: "locality",
           postalCode: "123",
-          country: "JP"
+          country: "JP",
+          feeAmount: 100
         },
         reference: "order_ref_1234567",
         successURL: "https://docs.smartpay.co/example-pages/checkout-successful",
@@ -66,7 +67,7 @@ RSpec.describe Smartpay::Requests::CheckoutSession do
     it do
       expect(subject.send(:normalize_payload)).to eq({
         orderData: {
-          amount: 250,
+          amount: 350,
           captureMethod: nil,
           confirmationMethod: nil,
           coupons: nil,
@@ -107,8 +108,8 @@ RSpec.describe Smartpay::Requests::CheckoutSession do
               subLocality: nil
             },
             addressType: nil,
-            feeAmount: nil,
-            feeCurrency: nil
+            feeAmount: 100,
+            feeCurrency: "JPY"
           }
         },
         reference: "order_ref_1234567",

--- a/spec/smartpay/requests/checkout_session_spec.rb
+++ b/spec/smartpay/requests/checkout_session_spec.rb
@@ -106,7 +106,9 @@ RSpec.describe Smartpay::Requests::CheckoutSession do
               postalCode: "123",
               subLocality: nil
             },
-            addressType: nil
+            addressType: nil,
+            feeAmount: nil,
+            feeCurrency: nil
           }
         },
         reference: "order_ref_1234567",
@@ -133,11 +135,134 @@ RSpec.describe Smartpay::Requests::CheckoutSession do
           phoneNumber: nil,
           reference: nil
         },
-        metadata: nil,
+        metadata: {},
         test: true
       })
     end
   end
+
+  describe '#normalize_payload_promotion' do
+    let(:request) do
+      {
+        items: [{
+          name: "オリジナルス STAN SMITH",
+          amount: 250,
+          currency: "JPY",
+          quantity: 1
+        }],
+        customer: {
+          accountAge: 20,
+          email: "merchant-support@smartpay.co",
+          firstName: "田中",
+          lastName: "太郎",
+          firstNameKana: "たなか",
+          lastNameKana: "たろう",
+          address: {
+            line1: "3-6-7",
+            line2: "青山パラシオタワー 11階",
+            subLocality: "",
+            locality: "港区北青山",
+            administrativeArea: "東京都",
+            postalCode: "107-0061",
+            country: "JP"
+          },
+          dateOfBirth: "1985-06-30",
+          gender: "male"
+        },
+        shipping: {
+          line1: "line1",
+          locality: "locality",
+          postalCode: "123",
+          country: "JP"
+        },
+        reference: "order_ref_1234567",
+        successURL: "https://docs.smartpay.co/example-pages/checkout-successful",
+        cancelURL: "https://docs.smartpay.co/example-pages/checkout-canceled",
+        promotionCode: "FOO",
+        test: true
+      }
+    end
+
+    it do
+      expect(subject.send(:normalize_payload)).to eq({
+        orderData: {
+          amount: 250,
+          captureMethod: nil,
+          confirmationMethod: nil,
+          coupons: nil,
+          currency: "JPY",
+          lineItemData: [{
+            description: nil,
+            metadata: nil,
+            price: nil,
+            priceData: {
+              amount: 250,
+              currency: "JPY",
+              metadata: nil,
+              productData: {
+                brand: nil,
+                categories: nil,
+                description: nil,
+                gtin: nil,
+                images: nil,
+                metadata: nil,
+                name: "オリジナルス STAN SMITH",
+                reference: nil,
+                url: nil
+              }
+            },
+            quantity: 1
+          }],
+          shippingInfo: {
+            address: {
+              administrativeArea: nil,
+              country: "JP",
+              line1: "line1",
+              line2: nil,
+              line3: nil,
+              line4: nil,
+              line5: nil,
+              locality: "locality",
+              postalCode: "123",
+              subLocality: nil
+            },
+            addressType: nil,
+            feeAmount: nil,
+            feeCurrency: nil
+          }
+        },
+        reference: "order_ref_1234567",
+        successUrl: "https://docs.smartpay.co/example-pages/checkout-successful",
+        cancelUrl: "https://docs.smartpay.co/example-pages/checkout-canceled",
+        customerInfo: {
+          accountAge: 20,
+          address: {
+            administrativeArea: "東京都",
+            country: "JP",
+            line1: "3-6-7",
+            line2: "青山パラシオタワー 11階",
+            locality: "港区北青山",
+            postalCode: "107-0061",
+            subLocality: ""
+          },
+          dateOfBirth: "1985-06-30",
+          emailAddress: "merchant-support@smartpay.co",
+          firstName: "田中",
+          firstNameKana: "たなか",
+          lastName: "太郎",
+          lastNameKana: "たろう",
+          legalGender: "male",
+          phoneNumber: nil,
+          reference: nil
+        },
+        metadata: {
+          "__promotion_code__": "FOO"
+        },
+        test: true
+      })
+    end
+  end
+
 
   describe '#normalize_customer_info' do
     let(:request) { {} }
@@ -187,7 +312,9 @@ RSpec.describe Smartpay::Requests::CheckoutSession do
             postalCode: nil,
             subLocality: nil
           },
-          addressType: nil
+          addressType: nil,
+          feeAmount: nil,
+          feeCurrency: nil
         })
       end
     end

--- a/spec/smartpay/responses/checkout_session_spec.rb
+++ b/spec/smartpay/responses/checkout_session_spec.rb
@@ -26,3 +26,23 @@ RSpec.describe Smartpay::Responses::CheckoutSession do
     it { expect(subject.as_json).to be_a(String) }
   end
 end
+
+RSpec.describe Smartpay::Responses::CheckoutSession do
+  subject { Smartpay::Responses::CheckoutSession.new(response) }
+
+  let(:response) { JSON.parse(File.read("./spec/fixtures/checkout_session_promotion.json"), symbolize_names: true) }
+
+  before do
+    Smartpay.configuration.checkout_url  = 'https://checkout.smartpay.test'
+    Smartpay.configuration.public_key  = 'pk_test_1234'
+  end
+
+  describe '#redirect_url' do
+    it do
+      expect(subject.redirect_url).to eq(
+        'https://checkout.smartpay.test/login?session-id=checkout_test_oTQpCvZzZ52UvKbrN5i4B8&public-key=pk_test_1234&promotion-code=ZOO'
+      )
+    end
+  end
+
+end


### PR DESCRIPTION
- Supports promotion-code
- Supports SMARTPAY_CHECKOUT_URL env var
- Fix order amount didn't include the shipping fee
- Rubocop target set to 2.5
- Several style fix