### PR TITLE
feat(sc-3395): Add get_orders method and end-end tests with basic test cases

### DIFF
--- a/lib/smartpay.rb
+++ b/lib/smartpay.rb
@@ -8,6 +8,7 @@ require_relative "smartpay/client"
 require_relative "smartpay/api"
 require_relative "smartpay/errors/invalid_request_payload_error"
 require_relative "smartpay/requests/checkout_session"
+require_relative "smartpay/responses/base"
 require_relative "smartpay/responses/checkout_session"
 
 module Smartpay

--- a/lib/smartpay/api.rb
+++ b/lib/smartpay/api.rb
@@ -8,6 +8,10 @@ module Smartpay
           Client.post("/checkout-sessions", Requests::CheckoutSession.new(payload).as_hash)
         )
       end
+
+      def get_orders(page_token: '', limit: 20)
+        Responses::Base.new(Client.get("/orders", { pageToken: page_token, maxResults: limit }))
+      end
     end
   end
 end

--- a/lib/smartpay/client.rb
+++ b/lib/smartpay/client.rb
@@ -5,6 +5,14 @@ require "rest-client"
 module Smartpay
   class Client
     class << self
+      def get(path, payload = {})
+        request_payload = default_payload.merge(payload)
+        response = RestClient::Request.execute(method: :get, url: api_url(path),
+                                               headers: headers.merge(params: request_payload),
+                                               timeout: timeout)
+        JSON.parse(response.body, symbolize_names: true)
+      end
+
       def post(path, payload = {})
         request_payload = default_payload.merge(payload)
         response = RestClient::Request.execute(method: :post, url: api_url(path), headers: headers, timeout: timeout,

--- a/lib/smartpay/responses/base.rb
+++ b/lib/smartpay/responses/base.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Smartpay
+  module Responses
+    class Base
+      attr_reader :response
+
+      def initialize(response)
+        @response = response
+      end
+
+      def as_hash
+        @response
+      end
+
+      def as_json
+        @response.to_json
+      end
+    end
+  end
+end

--- a/lib/smartpay/responses/checkout_session.rb
+++ b/lib/smartpay/responses/checkout_session.rb
@@ -2,12 +2,7 @@
 
 module Smartpay
   module Responses
-    class CheckoutSession
-      attr_reader :response
-
-      def initialize(response)
-        @response = response
-      end
+    class CheckoutSession < Base
 
       def redirect_url(options = {})
         url = "#{checkout_url}/login"
@@ -16,14 +11,6 @@ module Smartpay
         qs = "#{qs}&promotion-code=#{URI.encode_www_form_component(promotion_code)}" if promotion_code
         
         "#{url}?#{qs}"
-      end
-
-      def as_hash
-        @response
-      end
-
-      def as_json
-        @response.to_json
       end
 
       private

--- a/spec/integration/api_spec.rb
+++ b/spec/integration/api_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+RSpec.describe Smartpay::Api do
+  before do
+    Smartpay.configure do |config|
+      config.public_key = ENV['SMARTPAY_PUBLIC_KEY']
+      config.secret_key = ENV['SMARTPAY_SECRET_KEY']
+    end
+  end
+
+  describe '.create_checkout_session' do
+    context 'with valid request payload' do
+      it do
+        session = Smartpay::Api.create_checkout_session({
+          items: [
+            {
+              name: 'オリジナルス STAN SMITH',
+              amount: 250,
+              currency: 'JPY',
+              quantity: 1,
+            },
+          ],
+          customer: {
+            accountAge: 20,
+            email: 'merchant-support@smartpay.co',
+            firstName: '田中',
+            lastName: '太郎',
+            firstNameKana: 'たなか',
+            lastNameKana: 'たろう',
+            address: {
+              line1: '北青山 3-6-7',
+              line2: '青山パラシオタワー 11階',
+              subLocality: '',
+              locality: '港区',
+              administrativeArea: '東京都',
+              postalCode: '107-0061',
+              country: 'JP',
+            },
+            dateOfBirth: '1985-06-30',
+            gender: 'male',
+          },
+          shipping: {
+            line1: '北青山 3-6-7',
+            line2: '青山パラシオタワー 11階',
+            subLocality: '',
+            locality: '港区',
+            administrativeArea: '東京都',
+            postalCode: '107-0061',
+            country: 'JP',
+          },
+          reference: 'order_ref_1234567',
+          successURL: 'https://docs.smartpay.co/example-pages/checkout-successful',
+          cancelURL: 'https://docs.smartpay.co/example-pages/checkout-canceled',
+        })
+        expect(session.response).not_to be_empty
+        expect(session.redirect_url).not_to be_empty
+      end
+    end
+  end
+
+  describe '.get_orders' do
+    context 'with valid params' do
+      it do
+        orders = Smartpay::Api.get_orders(
+          page_token: 'cjPY2pcYqrjRybZOgW7cIfpNSfp9vnJlMn21K1wET4bqn5tpFUzyhe4SG4kzQtADU2H9gCUk624crc78mJb9x0F2pZjc',
+          limit: 1,
+        )
+        expect(orders.response).not_to be_empty
+        expect(orders.response[:data].size).to be 1
+      end
+    end
+  end
+end

--- a/spec/smartpay/api_spec.rb
+++ b/spec/smartpay/api_spec.rb
@@ -10,4 +10,11 @@ RSpec.describe Smartpay::Api do
       })).to be_an_instance_of(Smartpay::Responses::CheckoutSession)
     end
   end
+
+  describe '.get_orders' do
+    it do
+      expect(Smartpay::Client).to receive(:get).with('/orders', { page: 1, count: 20 }).once
+      expect(Smartpay::Api.get_orders).to be_an_instance_of(Smartpay::Responses::Base)
+    end
+  end
 end


### PR DESCRIPTION
Commit 1:

- Add get_orders method to API, which follow the API spec: https://api-doc.smartpay.co/reference/list-orders

Commit 2:

- Add integration tests for APIs
    - checkout session
    - get orders)