### PR TITLE
Carawang/sc 3437/feature

### DIFF
--- a/lib/smartpay/requests/checkout_session.rb
+++ b/lib/smartpay/requests/checkout_session.rb
@@ -29,9 +29,6 @@ module Smartpay
       def normalize_payload
         currency = get_currency
         total_amount = get_total_amount
-        promotion_code = payload.dig(:promotionCode)
-        metadata = payload.dig(:metadata) || {}
-        metadata[:__promotion_code__] = promotion_code if promotion_code
         shippingInfo = payload.dig(:shippingInfo) || normalize_shipping(payload.dig(:shipping))
         shippingInfo[:feeCurrency] = currency if shippingInfo && shippingInfo[:feeCurrency].nil? && !(shippingInfo[:feeAmount].nil?)
 
@@ -46,10 +43,9 @@ module Smartpay
             shippingInfo: shippingInfo,
             lineItemData: payload.dig(:orderData, :lineItemData) || payload.dig(:items),
             description: payload.dig(:orderDescription),
-            metadata: payload.dig(:orderMetadata)
+            metadata: payload.dig(:orderMetadata),
+            reference: payload.dig(:reference),
           }),
-          reference: payload.dig(:reference),
-          metadata: metadata,
           successUrl: payload.dig(:successURL),
           cancelUrl: payload.dig(:cancelURL),
           test: payload.dig(:test) || false
@@ -106,7 +102,9 @@ module Smartpay
           confirmationMethod: order.dig(:confirmationMethod),
           coupons: order.dig(:coupons),
           shippingInfo: order.dig(:shippingInfo),
-          lineItemData: normalize_line_items(order.dig(:lineItemData) || order.dig(:items))
+          lineItemData: normalize_line_items(order.dig(:lineItemData) || order.dig(:items)),
+          metadata: order.dig(:metadata) || {},
+          reference: order.dig(:reference)
         }
       end
 

--- a/spec/smartpay/requests/checkout_session_spec.rb
+++ b/spec/smartpay/requests/checkout_session_spec.rb
@@ -110,9 +110,10 @@ RSpec.describe Smartpay::Requests::CheckoutSession do
             addressType: nil,
             feeAmount: 100,
             feeCurrency: "JPY"
-          }
+          },
+          metadata: {},
+          reference: "order_ref_1234567",
         },
-        reference: "order_ref_1234567",
         successUrl: "https://docs.smartpay.co/example-pages/checkout-successful",
         cancelUrl: "https://docs.smartpay.co/example-pages/checkout-canceled",
         customerInfo: {
@@ -136,134 +137,10 @@ RSpec.describe Smartpay::Requests::CheckoutSession do
           phoneNumber: nil,
           reference: nil
         },
-        metadata: {},
         test: true
       })
     end
   end
-
-  describe '#normalize_payload_promotion' do
-    let(:request) do
-      {
-        items: [{
-          name: "オリジナルス STAN SMITH",
-          amount: 250,
-          currency: "JPY",
-          quantity: 1
-        }],
-        customer: {
-          accountAge: 20,
-          email: "merchant-support@smartpay.co",
-          firstName: "田中",
-          lastName: "太郎",
-          firstNameKana: "たなか",
-          lastNameKana: "たろう",
-          address: {
-            line1: "3-6-7",
-            line2: "青山パラシオタワー 11階",
-            subLocality: "",
-            locality: "港区北青山",
-            administrativeArea: "東京都",
-            postalCode: "107-0061",
-            country: "JP"
-          },
-          dateOfBirth: "1985-06-30",
-          gender: "male"
-        },
-        shipping: {
-          line1: "line1",
-          locality: "locality",
-          postalCode: "123",
-          country: "JP"
-        },
-        reference: "order_ref_1234567",
-        successURL: "https://docs.smartpay.co/example-pages/checkout-successful",
-        cancelURL: "https://docs.smartpay.co/example-pages/checkout-canceled",
-        promotionCode: "FOO",
-        test: true
-      }
-    end
-
-    it do
-      expect(subject.send(:normalize_payload)).to eq({
-        orderData: {
-          amount: 250,
-          captureMethod: nil,
-          confirmationMethod: nil,
-          coupons: nil,
-          currency: "JPY",
-          lineItemData: [{
-            description: nil,
-            metadata: nil,
-            price: nil,
-            priceData: {
-              amount: 250,
-              currency: "JPY",
-              metadata: nil,
-              productData: {
-                brand: nil,
-                categories: nil,
-                description: nil,
-                gtin: nil,
-                images: nil,
-                metadata: nil,
-                name: "オリジナルス STAN SMITH",
-                reference: nil,
-                url: nil
-              }
-            },
-            quantity: 1
-          }],
-          shippingInfo: {
-            address: {
-              administrativeArea: nil,
-              country: "JP",
-              line1: "line1",
-              line2: nil,
-              line3: nil,
-              line4: nil,
-              line5: nil,
-              locality: "locality",
-              postalCode: "123",
-              subLocality: nil
-            },
-            addressType: nil,
-            feeAmount: nil,
-            feeCurrency: nil
-          }
-        },
-        reference: "order_ref_1234567",
-        successUrl: "https://docs.smartpay.co/example-pages/checkout-successful",
-        cancelUrl: "https://docs.smartpay.co/example-pages/checkout-canceled",
-        customerInfo: {
-          accountAge: 20,
-          address: {
-            administrativeArea: "東京都",
-            country: "JP",
-            line1: "3-6-7",
-            line2: "青山パラシオタワー 11階",
-            locality: "港区北青山",
-            postalCode: "107-0061",
-            subLocality: ""
-          },
-          dateOfBirth: "1985-06-30",
-          emailAddress: "merchant-support@smartpay.co",
-          firstName: "田中",
-          firstNameKana: "たなか",
-          lastName: "太郎",
-          lastNameKana: "たろう",
-          legalGender: "male",
-          phoneNumber: nil,
-          reference: nil
-        },
-        metadata: {
-          "__promotion_code__": "FOO"
-        },
-        test: true
-      })
-    end
-  end
-
 
   describe '#normalize_customer_info' do
     let(:request) { {} }
@@ -337,7 +214,9 @@ RSpec.describe Smartpay::Requests::CheckoutSession do
           coupons: nil,
           currency: nil,
           lineItemData: [],
-          shippingInfo: nil
+          shippingInfo: nil,
+          metadata: {},
+          reference: nil,
         })
       end
     end

--- a/spec/smartpay/responses/checkout_session_spec.rb
+++ b/spec/smartpay/responses/checkout_session_spec.rb
@@ -11,10 +11,24 @@ RSpec.describe Smartpay::Responses::CheckoutSession do
   end
 
   describe '#redirect_url' do
-    it do
-      expect(subject.redirect_url).to eq(
-        'https://checkout.smartpay.test/login?session-id=checkout_test_oTQpCvZzZ52UvKbrN5i4B8&public-key=pk_test_1234'
-      )
+    context 'without promotion code' do
+      it do
+        expect(subject.redirect_url).to eq(
+          'https://checkout.smartpay.test/login?session-id=checkout_test_oTQpCvZzZ52UvKbrN5i4B8&public-key=pk_test_1234'
+        )
+      end
+    end
+
+    context 'with promotion code' do
+      let(:response) { JSON.parse(File.read("./spec/fixtures/checkout_session_promotion.json"), symbolize_names: true) }
+
+      describe '#redirect_url' do
+        it do
+          expect(subject.redirect_url).to eq(
+            'https://checkout.smartpay.test/login?session-id=checkout_test_oTQpCvZzZ52UvKbrN5i4B8&public-key=pk_test_1234&promotion-code=ZOO'
+          )
+        end
+      end
     end
   end
 
@@ -25,24 +39,4 @@ RSpec.describe Smartpay::Responses::CheckoutSession do
   describe '#as_json' do
     it { expect(subject.as_json).to be_a(String) }
   end
-end
-
-RSpec.describe Smartpay::Responses::CheckoutSession do
-  subject { Smartpay::Responses::CheckoutSession.new(response) }
-
-  let(:response) { JSON.parse(File.read("./spec/fixtures/checkout_session_promotion.json"), symbolize_names: true) }
-
-  before do
-    Smartpay.configuration.checkout_url  = 'https://checkout.smartpay.test'
-    Smartpay.configuration.public_key  = 'pk_test_1234'
-  end
-
-  describe '#redirect_url' do
-    it do
-      expect(subject.redirect_url).to eq(
-        'https://checkout.smartpay.test/login?session-id=checkout_test_oTQpCvZzZ52UvKbrN5i4B8&public-key=pk_test_1234&promotion-code=ZOO'
-      )
-    end
-  end
-
 end


### PR DESCRIPTION
The implementation in this PR mainly references the commit in node SDK:

https://github.com/smartpay-co/sdk-python/commit/4f358925c42dd804b8b1a93e665d0d62c8357501

- reorganize the request payload: move the keys of reference and metadata to the hash of orderData
- remove promotion code from metadata (-> not sure if this change are necessary)

note:

The first commit is minor refactor to meet the RSpec best practice by this documentation: https://www.betterspecs.org/